### PR TITLE
feat: add swift 5.5 async versions of most Command methods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,4 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
@@ -11,21 +9,24 @@ let package = Package(
     products: [
         .library(
             name: "swsh",
-            targets: ["swsh"]),
+            targets: ["swsh"]
+        ),
     ],
-    dependencies: [
-    ],
+    dependencies: [],
     targets: [
         .target(
             name: "swsh",
             dependencies: [
                 .target(name: "linuxSpawn", condition: .when(platforms: [.linux])),
-            ]),
+            ]
+        ),
         .testTarget(
             name: "swshTests",
-            dependencies: ["swsh"]),
+            dependencies: ["swsh"]
+        ),
         .target(
             name: "linuxSpawn",
-            dependencies: []),
+            dependencies: []
+        ),
     ]
 )

--- a/Sources/swsh/Command+async.swift
+++ b/Sources/swsh/Command+async.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+extension Command {
+    // MARK: - Running
+
+    /// Run the command asynchronously, and return nothing if successful
+    /// - Throws: if command fails
+    @available(macOS 10.15, *)
+    public func run() async throws {
+        try await async().succeed()
+    }
+
+    /// Run the command asynchronously, and return true if the command exited zero
+    @available(macOS 10.15, *)
+    public func runBool() async -> Bool {
+        await async().exitCode() == 0
+    }
+
+    /// Run the command synchronously, directing the output to a temporary file
+    /// - Returns: URL of temporary file with output of command
+    /// - Throws: if command fails
+    @available(macOS 10.15, *)
+    public func runFile() async throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+          .appendingPathComponent(UUID().uuidString, isDirectory: false)
+        try await self.output(creatingFile: url.path).run()
+        return url
+    }
+
+    /// Run the command synchronously, and collect stdout.
+    /// does not trim newlines (unlike $(...))
+    /// - Throws: if command fails
+    /// - Returns: output as Data
+    @available(macOS 10.15, *)
+    public func runData() async throws -> Data {
+        let pipe = Pipe()
+        let write = pipe.fileHandleForWriting
+        let result = async(fdMap: [ .stdout: write.fd ])
+        close(write.fileDescriptor)
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        try await result.succeed()
+        return data
+    }
+
+    /// Run the command asynchronously, and collect stdout into a string.
+    /// Trims trailing newlines (like $(...))
+    /// - Parameter encoding: the encoding of the output data
+    /// - Throws: if command fails
+    /// - Throws: `InvalidString` if the output isn't valid
+    /// - Returns: output as unicode string
+    @available(macOS 10.15, *)
+    public func runString(encoding: String.Encoding = .utf8) async throws -> String {
+        let data = try await runData()
+        guard let string = String(data: data, encoding: encoding) else {
+            throw InvalidString(data: data, encoding: encoding)
+        }
+        guard let trimStop = string.lastIndex(where: { $0 != "\n" }) else {
+            return ""
+        }
+        return String(string[...trimStop])
+    }
+
+    /// Run the command asynchronously, and collect output line-by-line as a list of strings
+    /// - Throws: if command fails
+    @available(macOS 10.15, *)
+    public func runLines(encoding: String.Encoding = .utf8) async throws -> [String] {
+        let lines = try await runString(encoding: encoding).split(separator: "\n", omittingEmptySubsequences: false)
+        return lines.map(String.init)
+    }
+
+    /// Run the command asynchronously, and collect output as a parsed JSON object
+    /// - Throws: if command fails
+    /// - Throws: if the output isn't JSON
+    @available(macOS 10.15, *)
+    public func runJSON(options: JSONSerialization.ReadingOptions = .allowFragments) async throws -> Any {
+        try JSONSerialization.jsonObject(with: await runData(), options: options)
+    }
+
+    /// Run the command asynchronously, and collect output as a parsed JSON object
+    /// - Throws: if command fails
+    /// - Throws: if parsing fails
+    @available(macOS 10.15, *)
+    public func runJSON<D: Decodable>(_ type: D.Type, decoder: JSONDecoder? = nil) async throws -> D {
+        let decoder = decoder ?? JSONDecoder()
+        return try decoder.decode(type, from: await runData())
+    }
+}
+
+#endif

--- a/Sources/swsh/CommandResult+async.swift
+++ b/Sources/swsh/CommandResult+async.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, *)
+internal protocol AsyncCommandResult: CommandResult {
+    func asyncFinish() async
+}
+
+extension CommandResult {
+    func withSyncContext<R>(f: () throws -> R) rethrows -> R { try f() }
+
+    @available(macOS 10.15, *)
+    internal func asyncFinishInternal() async {
+        if let asyncSelf = self as? AsyncCommandResult {
+            await asyncSelf.asyncFinish()
+        } else {
+            _ = await Task { exitCode() }.result
+        }
+    }
+
+    /// return exit code asynchronously
+    @available(macOS 10.15, *)
+    public func exitCode() async -> Int32 {
+        await asyncFinishInternal()
+        return withSyncContext { exitCode() }
+    }
+
+    /// throw an error if exitCode is non-zero asynchronously
+    @available(macOS 10.15, *)
+    public func succeed() async throws {
+        await asyncFinishInternal()
+        return try withSyncContext { try succeed() }
+    }
+
+    /// Wait for the command to finish, ignoring any exit code
+    @discardableResult
+    @available(macOS 10.15, *)
+    public func finish() async -> Self {
+        await asyncFinishInternal()
+        return self
+    }
+}
+
+#else
+
+protocol AsyncCommandResult: CommandResult {}
+
+#endif

--- a/Sources/swsh/FDWrapperCommand.swift
+++ b/Sources/swsh/FDWrapperCommand.swift
@@ -35,7 +35,7 @@ internal class FDWrapperCommand: Command {
         }
     }
 
-    struct Result: CommandResult {
+    struct Result: CommandResult, AsyncCommandResult {
         let innerResult: CommandResult
         let command: Command
         let ref: Any?
@@ -44,6 +44,13 @@ internal class FDWrapperCommand: Command {
         func exitCode() -> Int32 { innerResult.exitCode() }
         func succeed() throws { try innerResult.succeed() }
         func kill(signal: Int32) throws { try innerResult.kill(signal: signal) }
+
+        #if compiler(>=5.5) && canImport(_Concurrency)
+        @available(macOS 10.15, *)
+        func asyncFinish() async {
+            await innerResult.asyncFinishInternal()
+        }
+        #endif
     }
 
     func coreAsync(fdMap incoming: FDMap) -> CommandResult {

--- a/Tests/swshTests/Extensions/XCTestCase+Extensions.swift
+++ b/Tests/swshTests/Extensions/XCTestCase+Extensions.swift
@@ -27,4 +27,20 @@ extension XCTestCase {
         return e
     }
     #endif
+
+    // From https://www.wwt.com/article/unit-testing-on-ios-with-async-await
+    func XCTAssertThrowsAsyncError(
+        _ expression: @autoclosure () async throws -> Any,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ errorHandler: (_ error: Error) -> Void = { _ in }
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail(message(), file: file, line: line)
+        } catch {
+            errorHandler(error)
+        }
+    }
 }

--- a/Tests/swshTests/integration-tests/AsyncIntegrationTests.swift
+++ b/Tests/swshTests/integration-tests/AsyncIntegrationTests.swift
@@ -1,0 +1,43 @@
+import swsh
+import XCTest
+
+final class AsyncIntegrationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        ExternalCommand.verbose = true
+    }
+
+    func testRunStringSucceeds() async throws {
+        for newlines in ["", "\n", "\\n", "\\n\\n"] {
+            let result = try await cmd("printf", "%s %s\(newlines)", "hello,", "world!").runString()
+            XCTAssertEqual(result, "hello, world!" )
+        }
+    }
+
+    func testPipes() async throws {
+        try await Pipeline(cmd("echo", "foo"), cmd("cat"), cmd("cat")).run()
+    }
+
+    func testRunBoolTrue() async {
+        let result = await cmd("true").runBool()
+        XCTAssertTrue(result)
+    }
+
+    func testRunBoolFalse() async {
+        let result = await cmd("false").runBool()
+        XCTAssertFalse(result)
+    }
+
+    func testFalseRun() async {
+        await XCTAssertThrowsAsyncError(try await cmd("false").run()) { error in
+            XCTAssertEqual("\(error)", "command \"false\" failed with exit code 1")
+        }
+    }
+
+    func testPipeFailFails() async {
+        let result0 = await (cmd("false") | cmd("true")).runBool()
+        let result1 = await (cmd("true") | cmd("false")).runBool()
+        XCTAssertFalse(result0)
+        XCTAssertFalse(result1)
+    }
+}

--- a/Tests/swshTests/mocks/AsyncMockCommand.swift
+++ b/Tests/swshTests/mocks/AsyncMockCommand.swift
@@ -1,0 +1,19 @@
+@testable import swsh
+import XCTest
+
+class AsyncMockCommand: MockCommand {
+    class AsyncResult: MockCommand.Result, AsyncCommandResult {
+        func asyncFinish() async {
+            // Not a good idea outside of a test, as one thread will be blocked until this finishes
+            _ = await Task {
+                withSyncContext { finish() }
+            }.result
+        }
+    }
+
+    override func coreAsync(fdMap: FDMap) -> CommandResult {
+        let result = AsyncResult(command: self, fdMap: fdMap)
+        resultCallback?(result)
+        return result
+    }
+}

--- a/Tests/swshTests/unit-tests/CommandConcurrencyTests.swift
+++ b/Tests/swshTests/unit-tests/CommandConcurrencyTests.swift
@@ -1,0 +1,190 @@
+@testable import swsh
+import XCTest
+
+class CommandConcurrencyTests: XCTestCase {
+    // MARK: Utilities
+
+    func sync<R>(body: @escaping () async throws -> R) throws -> R {
+        // Expectations in async tests are currently broken on linux, so we need a way to force an async environment
+        let semaphore = DispatchSemaphore(value: 0)
+        let result = UnsafeMutablePointer<Result<R, Error>?>.allocate(capacity: 1)
+        result.initialize(to: nil)
+        defer {
+            result.deinitialize(count: 1)
+            result.deallocate()
+        }
+        Task {
+            do {
+                result.pointee = try await .success(body())
+            } catch let e {
+                result.pointee = .failure(e)
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return try result.pointee!.get()
+    }
+
+    let commandAndResult: (command: AsyncMockCommand, result: Task<AsyncMockCommand.Result, Never>) = {
+        let command = AsyncMockCommand()
+        return (
+            command,
+            Task {
+                await withCheckedContinuation { kont in
+                    command.resultCallback = {
+                        command.resultCallback = nil
+                        kont.resume(returning: $0)
+                    }
+                }
+            }
+        )
+    }()
+
+    func result() async -> AsyncMockCommand.Result {
+        await commandAndResult.result.value
+    }
+    var command: AsyncMockCommand { commandAndResult.command }
+
+    var str = "hello\n"
+    var data: Data { str.data(using: .utf8)! }
+    func echo(fds: [FileDescriptor] = [.stdout]) async {
+        let res = await result()
+        for fd in fds {
+            res[fd].write(self.data)
+            res[fd].closeFile()
+        }
+        res.setExit(code: 0)
+    }
+
+    // MARK: Tests
+
+    func testAsyncRunSucceedsAsynchronously() throws {
+        let finished = expectation(description: "run not finished")
+        finished.isInverted = true
+
+        let task = Task {
+            try await command.run()
+            finished.fulfill()
+        }
+
+        wait(for: [finished], timeout: 0.1)
+        try sync {
+            await self.result().setExit(code: 0)
+            try await task.result.get()
+        }
+    }
+
+    func testAsyncRunFails() throws {
+        let notFinished = expectation(description: "run not finished")
+        notFinished.isInverted = true
+
+        let task = Task {
+            try await self.command.run()
+            notFinished.fulfill()
+        }
+
+        Thread.sleep(forTimeInterval: 0.1)
+        try sync {
+            await self.result().setExit(code: 1)
+            await self.XCTAssertThrowsAsyncError(try await task.result.get()) { error in
+                if let error = error as? ExitCodeFailure {
+                    XCTAssertEqual(error.exitCode, 1)
+                } else {
+                    XCTFail("Expected ExitCodeFailure, got \(error)")
+                }
+            }
+        }
+        wait(for: [notFinished], timeout: 0.1)
+    }
+
+    func testAsyncRunSucceedsWithNonAsyncAwareCommand() throws {
+        let command = MockCommand()
+        var result: MockCommand.Result?
+        command.resultCallback = { result = $0 }
+
+        let finished = expectation(description: "run not finished")
+        finished.isInverted = true
+
+        let task = Task {
+            try await command.run()
+            finished.fulfill()
+        }
+
+        wait(for: [finished], timeout: 0.1)
+        try unwrap(result).setExit(code: 0)
+        try sync {
+            try await task.result.get()
+        }
+    }
+
+    func testAsyncFinishSucceeds() throws {
+        let task = Task {
+            await command.async().finish()
+        }
+        Thread.sleep(forTimeInterval: 0.1)
+        try sync {
+            await self.result().setExit(code: 1)
+            _ = try await task.result.get()
+        }
+    }
+
+    func testRunFile() throws {
+        Task { await echo() }
+        let url = try sync {
+            try await self.command.runFile()
+        }
+        XCTAssertEqual(try Data(contentsOf: url), data)
+    }
+
+    func testRunStringBlank() throws {
+        str = "\n\n"
+        Task { await echo() }
+        let result = try sync {
+            try await self.command.runString()
+        }
+        XCTAssertEqual(result, "")
+    }
+
+    func testRunStringBadEncoding() throws {
+        str = "Ünicode"
+        Task { await echo() }
+        try sync {
+            await self.XCTAssertThrowsAsyncError(try await self.command.runString(encoding: .nonLossyASCII))
+        }
+    }
+
+    func testRunLines() throws {
+        str = "a\nb\n\nc\n\n"
+        Task { await echo() }
+        let result = try sync { try await self.command.runLines() }
+        XCTAssertEqual(result, ["a", "b", "", "c"])
+    }
+
+    func testRunJSON() throws {
+        str = "{\"x\": [1, 2]}"
+        Task { await echo() }
+        let result = try sync { try await self.command.runJSON() }
+        XCTAssertEqual(result as? [String: [Int]], ["x": [1, 2]])
+    }
+
+    func testInvalidJSON() throws {
+        Task { await echo() }
+        try sync {
+            await self.XCTAssertThrowsAsyncError(try await self.command.runJSON())
+        }
+    }
+
+    func testJSONDecodable() throws {
+        str = "{\"x\": [1, 2]}"
+        Task { await echo() }
+        let result = try sync { try await self.command.runJSON([String: [Int]].self) }
+        XCTAssertEqual(result, ["x": [1, 2]])
+    }
+
+    func testInvalidJSONDecodable() throws {
+        Task { await echo() }
+        try sync {
+            await self.XCTAssertThrowsAsyncError(try await self.command.runJSON(Int.self))
+        }
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE: old synchronous versions of these methods can no longer
be called in asynchronous contexts